### PR TITLE
Implement question viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ To run for production:
 bun start
 ```
 
+### Environment variables
+
+Set `AI_DEVS_API_KEY` and `XYZ_AGENTS_ORG` before starting the server.
+Downloaded data is cached in the `data` directory.
+
 This project was created using `bun init` in bun v1.2.13. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,9 @@ export function App() {
         <CardContent className="pt-6">
           <h1 className="text-5xl font-bold my-4 leading-tight">Blank App</h1>
           <p>Start building your application using Feature-Sliced Design.</p>
+          <a href="/questions" className="text-primary underline">
+            View Questions
+          </a>
         </CardContent>
       </Card>
     </div>

--- a/src/frontend.tsx
+++ b/src/frontend.tsx
@@ -8,11 +8,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import HomePage from "@/pages/home/page";
+import QuestionsPage from "@/pages/questions/page";
 
 const elem = document.getElementById("root")!;
+const Page = window.location.pathname.startsWith("/questions")
+  ? QuestionsPage
+  : HomePage;
+
 const app = (
   <StrictMode>
-    <HomePage />
+    <Page />
   </StrictMode>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,56 @@
 import { serve } from "bun";
 import index from "./index.html";
+import { join } from "path";
+import { mkdir } from "fs/promises";
+
+const dataDir = join(process.cwd(), "data");
+const questionsPath = join(dataDir, "phone_questions.json");
+
+async function fetchQuestions() {
+  const cached = Bun.file(questionsPath);
+  if (await cached.exists()) {
+    const text = await cached.text();
+    return new Response(text, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const key = process.env.AI_DEVS_API_KEY;
+  const base = process.env.XYZ_AGENTS_ORG;
+  if (!base) {
+    return new Response("Base URL not configured", { status: 500 });
+  }
+  const url = `${base}data/${key}/phone_questions.json`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    return new Response("Failed to fetch questions", { status: 500 });
+  }
+  const text = await res.text();
+  await mkdir(dataDir, { recursive: true });
+  await Bun.write(questionsPath, text);
+  return new Response(text, {
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 const server = serve({
-  routes: {
-    // Serve index.html for all routes
-    "/*": index,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/api/questions") {
+      return fetchQuestions();
+    }
+
+    const file = Bun.file(join(".", url.pathname));
+    if (await file.exists()) {
+      return new Response(file);
+    }
+
+    return new Response(Bun.file(index));
   },
 
   development: process.env.NODE_ENV !== "production" && {
-    // Enable browser hot reloading in development
     hmr: true,
-
-    // Echo console logs from the browser to the server
     console: true,
   },
 });

--- a/src/pages/questions/page.tsx
+++ b/src/pages/questions/page.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent } from "@/shared/ui/card";
+
+export default function QuestionsPage() {
+  const [questions, setQuestions] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadQuestions = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/questions");
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) {
+          setQuestions(data);
+        } else if (data && typeof data === "object") {
+          setQuestions(Object.values(data));
+        } else {
+          setQuestions([]);
+        }
+      } else {
+        console.error("Failed to fetch questions");
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-8 text-center">
+      <Card className="bg-card/50 backdrop-blur-sm border-muted">
+        <CardContent className="pt-6">
+          <h1 className="text-3xl font-bold mb-4 leading-tight">Questions</h1>
+          <Button onClick={loadQuestions} disabled={loading}>
+            {loading ? "Loading..." : "Load Questions"}
+          </Button>
+          {questions && (
+            <ul className="mt-4 text-left list-disc list-inside">
+              {questions.map((q, idx) => (
+                <li key={idx}>{q}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Questions page
- link the new page from the home page
- route page rendering based on pathname
- expose server API route to download questions from `c3ntrala`
- cache questions with data folder and env-based URL
- remove default URL from README
- remove fallback base URL from server

## Testing
- `bun run build.ts`
- `bun run src/index.tsx` *(server started but questions fetch fails without proper env or network access)*


------
https://chatgpt.com/codex/tasks/task_e_684732cef4d48326ab8e1b02d32a9089