### PR TITLE
Add phone transcription feature

### DIFF
--- a/src/api/fetchPhone.ts
+++ b/src/api/fetchPhone.ts
@@ -1,0 +1,35 @@
+import { join } from "path";
+import { mkdir } from "fs/promises";
+
+const dataDir = join(process.cwd(), "data");
+const phonePath = join(dataDir, "phone.json");
+
+async function fetchPhone() {
+  const cached = Bun.file(phonePath);
+  if (await cached.exists()) {
+    const text = await cached.text();
+    return new Response(text, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const key = process.env.AI_DEVS_API_KEY;
+  const base = process.env.CENTRALA_URL;
+  if (!base) {
+    return new Response("Base URL not configured", { status: 500 });
+  }
+  const url = `${base}data/${key}/phone.json`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    return new Response("Failed to fetch phone data", { status: 500 });
+  }
+  const text = await res.text();
+  await mkdir(dataDir, { recursive: true });
+  await Bun.write(phonePath, text);
+  return new Response(text, {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export { fetchPhone };

--- a/src/features/conversation/model/usePhoneTranscription.ts
+++ b/src/features/conversation/model/usePhoneTranscription.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+export function usePhoneTranscription() {
+  const [transcription, setTranscription] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadTranscription = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/phone");
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) {
+          setTranscription(data);
+        } else if (data && typeof data === "object") {
+          setTranscription(Object.values(data));
+        } else {
+          setTranscription([]);
+        }
+      } else {
+        console.error("Failed to fetch phone data");
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { transcription, loading, loadTranscription };
+}

--- a/src/features/conversation/ui/PhoneTranscription.tsx
+++ b/src/features/conversation/ui/PhoneTranscription.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent } from "@/shared/ui/card";
+import { usePhoneTranscription } from "../model/usePhoneTranscription";
+
+export function PhoneTranscription() {
+  const { transcription, loading, loadTranscription } = usePhoneTranscription();
+
+  return (
+    <div className="container mx-auto p-8 text-center">
+      <Card className="bg-card/50 backdrop-blur-sm border-muted">
+        <CardContent className="pt-6">
+          <h1 className="text-3xl font-bold mb-4 leading-tight">
+            Phone Transcription
+          </h1>
+          <Button onClick={loadTranscription} disabled={loading}>
+            {loading ? "Loading..." : "Load Transcription"}
+          </Button>
+          {transcription && (
+            <ul className="mt-4 text-left list-disc list-inside">
+              {transcription.map((line, idx) => (
+                <li key={idx}>{line}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default PhoneTranscription;

--- a/src/frontend.tsx
+++ b/src/frontend.tsx
@@ -9,11 +9,14 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import HomePage from "@/pages/home/page";
 import QuestionsPage from "@/pages/questions/page";
+import PhoneTranscriptionPage from "@/pages/phone-transcription/page";
 
 const elem = document.getElementById("root")!;
 const Page = window.location.pathname.startsWith("/questions")
   ? QuestionsPage
-  : HomePage;
+  : window.location.pathname.startsWith("/phone-transcription")
+    ? PhoneTranscriptionPage
+    : HomePage;
 
 const app = (
   <StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,14 @@
 import { serve } from "bun";
 import index from "./index.html";
 import { fetchQuestions } from "@/api/fetchQuestions";
+import { fetchPhone } from "@/api/fetchPhone";
 
 const server = serve({
   routes: {
     // Serve index.html for all routes
     "/*": index,
     "/api/questions": fetchQuestions,
+    "/api/phone": fetchPhone,
   },
 
   development: process.env.NODE_ENV !== "production" && {

--- a/src/pages/phone-transcription/page.tsx
+++ b/src/pages/phone-transcription/page.tsx
@@ -1,0 +1,5 @@
+import PhoneTranscription from "@/features/conversation/ui/PhoneTranscription";
+
+export default function PhoneTranscriptionPage() {
+  return <PhoneTranscription />;
+}


### PR DESCRIPTION
## Summary
- fetch phone transcript from centrala API
- expose `/api/phone` endpoint
- add phone transcription feature slice and UI
- create phone-transcription page and client routing

## Testing
- `bun run build.ts --outdir temp`

------
https://chatgpt.com/codex/tasks/task_e_68473f06df70832697ec07ddeb0a7214